### PR TITLE
Fetch gradle

### DIFF
--- a/Scripts/Support/Editor/CustomBuild/CustomBuildSetupEnv/CustomBuildAndroidSetupEnv.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildSetupEnv/CustomBuildAndroidSetupEnv.cs
@@ -20,7 +20,7 @@ public class CustomBuildAndroidSetupEnv : CustomBuildSetupEnv
 
     public CustomBuildAndroidSetupEnv(AppcoinsGameObject a) : base(a) {}
 
-    internal override void Setup()
+    public override void Setup()
     {
         // Merge main templates
         Tools.MergeMainTemplates(currentMainTemplate, appcoinsMainTemplate);

--- a/Scripts/Support/Editor/CustomBuild/CustomBuildSetupEnv/CustomBuildSetupEnv.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildSetupEnv/CustomBuildSetupEnv.cs
@@ -11,7 +11,7 @@ public abstract class CustomBuildSetupEnv
         appcoinsGameObject = a;
     }
 
-    internal virtual void Setup()
+    public virtual void Setup()
     {
         try
         {

--- a/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System;
 using System.IO;
 using System.Collections;
+using System.Timers;
 
 // Draw the window for the user select what scenes he wants to export
 // and configure player settings.
@@ -21,7 +22,8 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
     private bool runAdbRun;
     private BuildStage lastBuildSatage;
     private string windowsPath = "C:\\Program Files\\Android\\Android Studio\\gradle";
-    private string macPath = "/Applications/Android Studio.app/Contentss/gradle";
+    private string macPath = "/Applications/Android Studio.app/Contents/gradle";
+    private string devPath;
     private string gradVersion;
 
     private string defaultGradleMem = "1536";
@@ -152,7 +154,7 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             instance.buildScenesEnabled[i] = GUI.Toggle(
                 new Rect(10, 10 + i * 20, xEnd - xEnd / 10, 20),
                 instance.buildScenesEnabled[i],
-                EditorBuildSettings.scenes[i].path 
+                EditorBuildSettings.scenes[i].path
             );
         }
         GUI.EndScrollView();
@@ -303,12 +305,12 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
         if (ExistsAndroidPath(SystemInfo.operatingSystemFamily ==
                               OperatingSystemFamily.Windows ? windowsPath : macPath))
         {
-            EditorPrefs.DeleteKey("appcoins_gradle_path");
-
-            // Debug.Log(EditorSkin.get)
+          
+            //Print console message to help developer keep track of process
             Debug.Log("Android studio directory exists");
 
-            GetGradleVersion(macPath);
+            GetGradleVersion(devPath);
+
             // If package name is different we assume that the user is working in 
             // a different unity project
             if (!Application.identifier.Equals(packageName))
@@ -369,14 +371,14 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
 
         else
         {
-
             //In case Android Studio is not Installed
             //User is asked to fill gradle path manually
+            WarningPopup();
+
+            //Print console message to help developer keep track of process
             Debug.Log("Android studio directory is non existing");
 
-            EditorPrefs.DeleteKey("appcoins_gradle_path");
-            //Invoke(WarningPopup(),1.0f);
-            WarningPopup();
+
             gradlePath = EditorPrefs.GetString("appcoins_gradle_path", "Gradle Path not found.Please fill it manually!");
 
 
@@ -408,33 +410,37 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
 
     // Process a directory 
     // and the subdirectories it contains.
-    public void GetGradleVersion(string targetDirectory)
+    protected void GetGradleVersion(string targetDirectory)
     {
 
         // Recurse into subdirectories of this directory.
         string[] subdirectoryEntries = Directory.GetDirectories(targetDirectory);
         foreach (string subdirectory in subdirectoryEntries)
-     
-            if(subdirectory.Contains("gradle-")){
+
+            if (subdirectory.Contains("gradle-"))
+            {
                 string[] vers = subdirectory.Split('-');
                 gradVersion = "gradle-" + vers[1];
                 Debug.Log("This is the gradVersion" + "\n" + gradVersion);
-        }
+            }
 
 
     }
 
-
-    public bool ExistsAndroidPath(string path1)
+    //Check if android is installed either on mac or windows
+    protected bool ExistsAndroidPath(string path1)
     {
         if (Directory.Exists(path1))
         {
+            devPath = path1;
             return true;
         }
         return false;
     }
 
-    public void WarningPopup(){
+    //Display warning popup window if graddle path is not found
+    protected void WarningPopup()
+    {
 
         EditorUtility.DisplayDialog("Warning", "Gradle Path not found. Please fill it manually!", "Close");
     }

--- a/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
@@ -152,7 +152,7 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             instance.buildScenesEnabled[i] = GUI.Toggle(
                 new Rect(10, 10 + i * 20, xEnd - xEnd / 10, 20),
                 instance.buildScenesEnabled[i],
-                EditorBuildSettings.scenes[i].path
+                EditorBuildSettings.scenes[i].path 
             );
         }
         GUI.EndScrollView();
@@ -373,8 +373,12 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             //In case Android Studio is not Installed
             //User is asked to fill gradle path manually
             Debug.Log("Android studio directory is non existing");
-            gradlePath = EditorPrefs.GetString(
-              "appcoins_gradle_path", "Gradle path not found. Insert directory manually!");
+
+            EditorPrefs.DeleteKey("appcoins_gradle_path");
+            //Invoke(WarningPopup(),1.0f);
+            WarningPopup();
+            gradlePath = EditorPrefs.GetString("appcoins_gradle_path", "Gradle Path not found.Please fill it manually!");
+
 
             adbPath = EditorPrefs.GetString(
                "appcoins_adb_path",
@@ -428,5 +432,10 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             return true;
         }
         return false;
+    }
+
+    public void WarningPopup(){
+
+        EditorUtility.DisplayDialog("Warning", "Gradle Path not found. Please fill it manually!", "Close");
     }
 }

--- a/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
+++ b/Scripts/Support/Editor/CustomBuild/CustomBuildWindow/AndroidCustomBuildWindow.cs
@@ -21,10 +21,9 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
     private string mainActivityPath;
     private bool runAdbRun;
     private BuildStage lastBuildSatage;
-    private string windowsPath = "C:\\Program Files\\Android\\Android Studio\\gradle";
-    private string macPath = "/Applications/Android Studio.app/Contents/gradle";
+    private string windowsPath = "C:\\Program Files\\Android\\Android Studio\\gradle\\";
+    private string macPath = "/Applications/Android Studio.app/Contents/gradle/";
     private string devPath;
-    private string gradVersion;
 
     private string defaultGradleMem = "1536";
     private string defaultDexMem = "1024";
@@ -309,7 +308,7 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             //Print console message to help developer keep track of process
             Debug.Log("Android studio directory exists");
 
-            GetGradleVersion(devPath);
+            string gradleVersion = GetGradleVersion(devPath);
 
             // If package name is different we assume that the user is working in 
             // a different unity project
@@ -317,8 +316,8 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             {
                 gradlePath = SystemInfo.operatingSystemFamily ==
                                        OperatingSystemFamily.Windows ?
-                "C:\\Program Files\\Android\\Android Studio\\gradle\\" + gradVersion + "\\bin\\gradle" :
-                "/Applications/Android Studio.app/Contents/gradle/" + gradVersion +
+                                       windowsPath + gradleVersion + "\\bin\\gradle" :
+                                       macPath + gradleVersion +
                     "/bin/";
 
                 adbPath = EditorPrefs.GetString("AndroidSdkRoot") +
@@ -339,8 +338,8 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
                 gradlePath = EditorPrefs.GetString(
                   "appcoins_gradle_path",
                     SystemInfo.operatingSystemFamily == OperatingSystemFamily.Windows ?
-                    "C:\\Program Files\\Android\\Android Studio\\gradle\\" + gradVersion + "\\bin\\gradle" :
-                    "/Applications/Android Studio.app/Contents/gradle/" + gradVersion +
+                    windowsPath + gradleVersion + "\\bin\\gradle" :
+                    macPath + gradleVersion +
                             "/bin/"
                 );
 
@@ -378,15 +377,13 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             //Print console message to help developer keep track of process
             Debug.Log("Android studio directory is non existing");
 
-
-            gradlePath = EditorPrefs.GetString("appcoins_gradle_path", "Gradle Path not found.Please fill it manually!");
-
+            gradlePath = "Gradle Path not found.Please fill it manually!";
 
             adbPath = EditorPrefs.GetString(
                "appcoins_adb_path",
                 EditorPrefs.GetString("AndroidSdkRoot") +
                       "/platform-tools/adb"
-        );
+            );
 
             mainActivityPath = EditorPrefs.GetString(
                 "appcoins_main_activity_path",
@@ -409,9 +406,11 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
     }
 
     // Process a directory 
-    // and the subdirectories it contains.
-    protected void GetGradleVersion(string targetDirectory)
+    // and the subdirectories it contains searching for the gradle folder to get its version
+    // Throws an error and returns NOT_FOUND string if not found
+    protected string GetGradleVersion(string targetDirectory)
     {
+        string gradleVersion = "NOT_FOUND";
 
         // Recurse into subdirectories of this directory.
         string[] subdirectoryEntries = Directory.GetDirectories(targetDirectory);
@@ -420,11 +419,15 @@ public class AndroidCustomBuildWindow : CustomBuildWindow
             if (subdirectory.Contains("gradle-"))
             {
                 string[] vers = subdirectory.Split('-');
-                gradVersion = "gradle-" + vers[1];
-                Debug.Log("This is the gradVersion" + "\n" + gradVersion);
+                gradleVersion = "gradle-" + vers[1];
+                Debug.Log("This is the gradVersion" + "\n" + gradleVersion);
+                return gradleVersion;
             }
 
 
+        Debug.LogError("Unable to determine gradle version");
+
+        return gradleVersion;
     }
 
     //Check if android is installed either on mac or windows


### PR DESCRIPTION
Fetch Gradle task done. This process was optimised. The Gradle path and its version are now automatically being fetched. In case there's a problem with Android Studio's path, or if it isn't installed in the developer's computer, a popup window will be launched informing the developer that the operation wasn't successful and that he must fill the Gradle path field manually.